### PR TITLE
colorimeter: cn0363_device: Fix spi name

### DIFF
--- a/lib/cn0363_device.py
+++ b/lib/cn0363_device.py
@@ -126,7 +126,7 @@ class Device(object):
 
         self.device = None
         self.zynq_gpio = GPIOController.get_by_name('zynq_gpio')
-        self.ad7175_gpio = GPIOController.get_by_name('spi32766.0')
+        self.ad7175_gpio = GPIOController.get_by_name('spi0.0')
         self.rdac = None
         for spi in os.listdir(SPI_DIR):
             if not os.path.isdir(os.path.join(SPI_DIR, spi)):


### PR DESCRIPTION
This patch changes the name of the spi device from spi32766 to spi0. 

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>

It seems that the device number is now 0. This fix is in response to https://jira.analog.com/browse/SDGREL-250
