### PR TITLE
colorimeter: make: Add pkexec policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,15 @@ PREFIX ?=/usr/local
 DESTDIR ?=/
 
 .PHONY : all
-all: capture.so adi-colorimeter.desktop lib/config.py
+all: capture.so adi-colorimeter.desktop lib/config.py org.adi.pkexec.adi_colorimeter.policy
 
 capture.so: capture.c
 	$(CC) -shared -o $@ $^ -liio -lm -Wall -Wextra -fPIC -std=gnu99 -pedantic -O3
 
 %.desktop: %.desktop.in
+	sed 's/@PREFIX@/$(subst /,\/,$(PREFIX))/' $+ > $@
+
+%.policy: %.policy.in
 	sed 's/@PREFIX@/$(subst /,\/,$(PREFIX))/' $+ > $@
 
 %.py: %.py.in
@@ -17,6 +20,7 @@ install: all
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -d $(DESTDIR)$(PREFIX)/share/adi_colorimeter/
 	install -d $(DESTDIR)$(PREFIX)/lib/adi_colorimeter/
+	install ./org.adi.pkexec.adi_colorimeter.policy /usr/share/polkit-1/actions 
 	install ./adi_colorimeter $(DESTDIR)$(PREFIX)/bin/
 	install ./capture.so $(DESTDIR)$(PREFIX)/lib/adi_colorimeter/
 	install ./adi_colorimeter.glade $(DESTDIR)$(PREFIX)/share/adi_colorimeter/
@@ -32,3 +36,4 @@ clean:
 	rm -f capture.so
 	rm -f adi-colorimeter.desktop
 	rm -f lib/config.py
+	rm -f org.adi.pkexec.adi_colorimeter.policy

--- a/adi-colorimeter.desktop.in
+++ b/adi-colorimeter.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Exec=gksudo -u root @PREFIX@/bin/adi_colorimeter
+Exec=pkexec -u root @PREFIX@/bin/adi_colorimeter-wrapper
 Icon=adi-colorimeter
 Terminal=false
 Type=Application

--- a/org.adi.pkexec.adi_colorimeter.policy.in
+++ b/org.adi.pkexec.adi_colorimeter.policy.in
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN" "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <vendor>Analog Devices Inc.</vendor>
+  <vendor_url>https://wiki.analog.com/resources/tools-software/linux-software/colorimeter</vendor_url>
+  <icon_name>adi-colorimeter</icon_name>
+  <action id="org.adi.pkexec.adi_colorimeter">
+    <description>CN0363 Colorimeter Application</description>
+    <message>Authentication is required to run colorimeter</message>
+    <defaults>
+      <allow_any>auth_admin_keep</allow_any>
+      <allow_inactive>auth_admin_keep</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@PREFIX@/bin/adi_colorimeter</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+</policyconfig>


### PR DESCRIPTION
Gksudo is no longer used to start applications with root privileges,
instead pkexec is the new norm. This patch add a policy for adi_colorimeter
to be able to run with pkexec.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>