### PR TITLE
Update to python3

### DIFF
--- a/adi-colorimeter.desktop.in
+++ b/adi-colorimeter.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Exec=pkexec -u root @PREFIX@/bin/adi_colorimeter-wrapper
+Exec=pkexec -u root @PREFIX@/bin/adi_colorimeter
 Icon=adi-colorimeter
 Terminal=false
 Type=Application

--- a/adi_colorimeter
+++ b/adi_colorimeter
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: iso-8859-15 -*-
 #
 # Copyright (C) 2014 Analog Devices, Inc.
@@ -34,6 +34,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gio, Gdk
 import threading
 import time
@@ -333,7 +335,7 @@ class ColorimeterDemo():
         self.infobar.connect("response", lambda w, r: w.hide())
         try:
             self.device = Device()
-        except Exception, e:
+        except Exception as e:
             self.show_info('Device not found: {}. Using demo device.'.format(e))
             print ("Device not found: %s" % str(e))
             self.device = FakeDevice()
@@ -361,7 +363,7 @@ class ColorimeterDemo():
 
         try:
             self.calib_data = self.import_calibration_data(os.path.expanduser('~/.colorimeter/calib_data'))
-        except Exception, e:
+        except Exception as e:
             print(e)
 
         if not dummy:
@@ -642,7 +644,7 @@ class ColorimeterDemo():
 
     def export_calibration_data(self, filename, calib_data):
         if not os.path.exists(os.path.dirname(filename)):
-            os.makedirs(os.path.dirname(filename), 0755)
+            os.makedirs(os.path.dirname(filename), 0o755)
         f = open(filename, 'w')
         f.write('%f %f %f %f %f %f %f' % (
             calib_data['offset'][self.CHANNEL_REFERENCE][self.GAIN_33k],

--- a/adi_colorimeter.glade
+++ b/adi_colorimeter.glade
@@ -513,7 +513,7 @@
                         <property name="margin_top">20</property>
                         <property name="margin_bottom">20</property>
                         <property name="xalign">0</property>
-                        <property name="pixbuf">/usr/local/share/osc/ADIlogo.png</property>
+                        <property name="pixbuf">/usr/local/share/osc/icons/ADIlogo.png</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -1231,7 +1231,7 @@
                         <property name="margin_top">20</property>
                         <property name="margin_bottom">20</property>
                         <property name="xalign">0</property>
-                        <property name="pixbuf">/usr/local/share/osc/ADIlogo.png</property>
+                        <property name="pixbuf">/usr/local/share/osc/icons/ADIlogo.png</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/lib/sample_library.py
+++ b/lib/sample_library.py
@@ -78,7 +78,7 @@ class SampleLibrary(object):
         self.location = location
         self.samples = []
         if not os.path.exists(os.path.dirname(location)):
-            os.makedirs(os.path.dirname(location), 0755)
+            os.makedirs(os.path.dirname(location), 0o755)
         else:
             for f in os.listdir(location):
                 f = os.path.join(location, f)
@@ -86,7 +86,7 @@ class SampleLibrary(object):
                     continue
                 try:
                     self.samples.append(Sample.load(f))
-                except Exception, e:
+                except Exception as e:
                     print(e)
 
     def __iter__(self):


### PR DESCRIPTION
Update python version so that the tool will use python3 (version 3.9 in kuiper case) by default instead of python2.
Fix also some methods/syntax that got modified with new python version.

Fix shortcut to colorimeter from Kuiper "Menu".