### PR TITLE
colorimeter: cn0363_device: Fix ad7175 gpio access

### DIFF
--- a/lib/cn0363_device.py
+++ b/lib/cn0363_device.py
@@ -161,9 +161,6 @@ class Device(object):
         self.gpio_color.append(self.ad7175_gpio.get_gpio(0))
         self.gpio_color.append(self.ad7175_gpio.get_gpio(1))
 
-        self.gpio_color[0].set_direction_output(True)
-        self.gpio_color[1].set_direction_output(True)
-
         self.gpio_gain = []
         self.gpio_gain.append(self.zynq_gpio.get_gpio(54 + 32))
         self.gpio_gain.append(self.zynq_gpio.get_gpio(54 + 33))


### PR DESCRIPTION
Upstream version of the ad7175 driver does not expose gpio direction control, they default to output.
Fix by removing direction setting.