### PR TITLE
Rebase 2023_R2 branch to latest main

### DIFF
--- a/lib/cn0363_device.py
+++ b/lib/cn0363_device.py
@@ -161,9 +161,6 @@ class Device(object):
         self.gpio_color.append(self.ad7175_gpio.get_gpio(0))
         self.gpio_color.append(self.ad7175_gpio.get_gpio(1))
 
-        self.gpio_color[0].set_direction_output(True)
-        self.gpio_color[1].set_direction_output(True)
-
         self.gpio_gain = []
         self.gpio_gain.append(self.zynq_gpio.get_gpio(54 + 32))
         self.gpio_gain.append(self.zynq_gpio.get_gpio(54 + 33))


### PR DESCRIPTION
The 'main' branch of colorimeter got updated to work with a newer version of python (the one used in kuiper2.0).
The 2022_r2 branch remained for previous python version (the one used by current kuiper).
"2023_r2" branch was created from 2022_r2 to be used by 2023_R2, and remained with old python version.