### PR TITLE
Change Makefile to facilitate .deb creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-PREFIX ?=/usr/local
+PREFIX ?= /usr/local
+DESTDIR ?=
+DEB_BUILD ?=0# default: manual install mode
 
 .PHONY : all
 all: capture.so adi-colorimeter.desktop lib/config.py org.adi.pkexec.adi_colorimeter.policy
@@ -16,24 +18,52 @@ capture.so: capture.c
 	sed 's/@PREFIX@/$(subst /,\/,$(PREFIX))/' $+ > $@
 
 install: all
-	install -d $(PREFIX)/bin
-	install -d $(PREFIX)/share/adi_colorimeter/
-	install -d $(PREFIX)/lib/adi_colorimeter/
-	install ./org.adi.pkexec.adi_colorimeter.policy /usr/share/polkit-1/actions/
-	install ./adi_colorimeter $(PREFIX)/bin/
-	install ./capture.so $(PREFIX)/lib/adi_colorimeter/
-	install ./adi_colorimeter.glade $(PREFIX)/share/adi_colorimeter/
-
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -d $(DESTDIR)$(PREFIX)/share/adi_colorimeter/
+	install -d $(DESTDIR)$(PREFIX)/lib/adi_colorimeter/
+	install -d $(DESTDIR)/usr/share/polkit-1/actions/
+	install ./org.adi.pkexec.adi_colorimeter.policy $(DESTDIR)/usr/share/polkit-1/actions/
+	install ./adi_colorimeter $(DESTDIR)$(PREFIX)/bin/
+	install ./capture.so $(DESTDIR)$(PREFIX)/lib/adi_colorimeter/
+	install ./adi_colorimeter.glade $(DESTDIR)$(PREFIX)/share/adi_colorimeter/
+ifeq ($(DEB_BUILD),0)
 	xdg-icon-resource install --noupdate --size 16 ./icons/adi-colorimeter16.png adi-colorimeter
 	xdg-icon-resource install --noupdate --size 32 ./icons/adi-colorimeter32.png adi-colorimeter
 	xdg-icon-resource install --size 64 ./icons/adi-colorimeter64.png adi-colorimeter
 	xdg-desktop-menu install adi-colorimeter.desktop
+else
+	install -d $(DESTDIR)$(PREFIX)/share/applications/
+	install -m 644 ./adi-colorimeter.desktop \
+		$(DESTDIR)/usr/share/applications/
+
+	install -d $(DESTDIR)$(PREFIX)/share/icons/hicolor/16x16/apps/
+	install -d $(DESTDIR)$(PREFIX)/share/icons/hicolor/32x32/apps/
+	install -d $(DESTDIR)$(PREFIX)/share/icons/hicolor/64x64/apps/
+	install -m 644 ./icons/adi-colorimeter16.png \
+		$(DESTDIR)$(PREFIX)/share/icons/hicolor/16x16/apps/adi-colorimeter.png
+	install -m 644 ./icons/adi-colorimeter32.png \
+		$(DESTDIR)$(PREFIX)/share/icons/hicolor/32x32/apps/adi-colorimeter.png
+	install -m 644 ./icons/adi-colorimeter64.png \
+		$(DESTDIR)$(PREFIX)/share/icons/hicolor/64x64/apps/adi-colorimeter.png
+endif
 
 uninstall:
-	rm -rf $(PREFIX)/share/adi_colorimeter
-	rm -rf $(PREFIX)/bin/adi_colorimeter
-	rm -rf $(PREFIX)/lib/adi_colorimeter
-	rm /usr/share/polkit-1/actions/org.adi.pkexec.adi_colorimeter.policy
+	rm -rf $(DESTDIR)$(PREFIX)/share/adi_colorimeter
+	rm -rf $(DESTDIR)$(PREFIX)/bin/adi_colorimeter
+	rm -rf $(DESTDIR)$(PREFIX)/lib/adi_colorimeter
+	rm -f $(DESTDIR)/usr/share/polkit-1/actions/org.adi.pkexec.adi_colorimeter.policy
+ifeq ($(DEB_BUILD),0)
+	xdg-icon-resource uninstall --size 16 adi-colorimeter
+	xdg-icon-resource uninstall --size 32 adi-colorimeter
+	xdg-icon-resource uninstall --size 64 adi-colorimeter
+	xdg-desktop-menu uninstall adi-colorimeter.desktop
+else
+	rm -f $(DESTDIR)$(PREFIX)/share/applications/adi-colorimeter.desktop
+	rm -f $(DESTDIR)$(PREFIX)/share/icons/hicolor/16x16/apps/adi-colorimeter.png
+	rm -f $(DESTDIR)$(PREFIX)/share/icons/hicolor/32x32/apps/adi-colorimeter.png
+	rm -f $(DESTDIR)$(PREFIX)/share/icons/hicolor/64x64/apps/adi-colorimeter.png
+endif
+
 
 .PHONY : clean
 clean:


### PR DESCRIPTION
I updated the Makefile in order to be easy to create .deb package using debhelper. 
All the paths were updated to support DESTDIR as a parameter 
I also updated the 'uninstall' target because the images and .desktop were left alone on the system 
Some `Ifeq` were added so the 'manual'(old) implementation still works for normal user, but setting the `DEB_BUILD` will help when creating the .deb

**Manual run**
<img width="1032" height="632" alt="make_manual" src="https://github.com/user-attachments/assets/d5e22b0a-7a36-48fc-8eaa-00fb32d3b903" />
---
**With parameter (for CI) run**
<img width="1103" height="949" alt="make_debian_package" src="https://github.com/user-attachments/assets/e33ec58e-c5c3-4dd6-acc4-90b2110225bf" />
<img width="406" height="516" alt="tree_debpackage" src="https://github.com/user-attachments/assets/2b387977-899d-4d78-88ca-f4ef4abd6c82" />



